### PR TITLE
Rework the layout of question pages

### DIFF
--- a/content/domains/identify/demonstrate-awareness-of-opioid-risk/post-assessment.md
+++ b/content/domains/identify/demonstrate-awareness-of-opioid-risk/post-assessment.md
@@ -6,17 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-The 40-year old patient from the previous section returns to the clinic two
-weeks after the emergency evaluation for a partially impacted wisdom tooth, which led
-to analgesic therapy and a referral to the oral surgeon for extraction of
-symptomatic tooth. When you enter the operatory, the patient introduces himself
-to you again, not remembering you from the last visit. The patient then begins
-to hold his jaw in agony, crying, claiming that he could not make it to the
-oral surgeon and ibuprofen was not enough for the pain. The patient then begins
-to reveal that he has a history of cocaine abuse and Motrin has never been able
-to work for pain - especially oral pain. The patient specifically asks for
-Percocet 5mg/325mg, because that is what has worked in the past due to his "very
-low threshold for pain."
-
 I’m familiar with screening (PDMP) and assessment (social history
 questionnaire) tools that would help to monitor a patient in this scenario.

--- a/content/domains/identify/importance-of-dental-providers-role/post-assessment.md
+++ b/content/domains/identify/importance-of-dental-providers-role/post-assessment.md
@@ -6,19 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-A 32-year old female patient presents for a 6-month periodic examination and
-cleaning. You have been providing dental treatment to this patient since they
-were 19 years old.
-
-Three years ago, when she was pregnant, you provided treatment and follow-up
-care for pregnancy gingivitis. Last year she was in a car accident and had to
-have surgery on her rotator cuff. You notice during this examination that her
-oral hygiene and home care is not as thorough as it once was. Due to your
-long-standing rapport with her, she divulges with you that she suffered from
-postpartum depression and the hydrocodone she was prescribed post shoulder
-surgery made her feel much better. She asks if, by chance, you could
-prescribe her hydrocodone, because of your history and how comfortable
-she has become with you.
-
 I feel prepared as a dental clinician to address the overall health
 (including non-dental) of my patient population.

--- a/content/domains/identify/screen-for-substance-disorders/post-assessment.md
+++ b/content/domains/identify/screen-for-substance-disorders/post-assessment.md
@@ -6,19 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-A 40-year old male patient presents to the clinic in acute pain. While the
-dental assistant begins to take diagnostic radiographs, the patient repeatedly
-dozes off. When you arrive at the operatory, the patient finishes a conversation
-on the telephone, and then begins to hold his face reporting excruciating pain.
-
-The patient's wisdom tooth is partially impacted with no caries, no pathology, and
-no inflammation of gingiva. As the patient begins to describe his symptoms, you
-notice some of his speech is slurred, and he becomes easily irritated with
-follow-up questions. When you begin your intraoral examination, the patient has
-poor oral hygiene with heavy plaque, heavy calculus build-up, and a poor odor.
-You decide to give the patient a prescription for Motrin 600mg, provide him
-with a referral to have the symptomatic tooth extracted at an oral surgeon's
-office close to your location, and schedule a follow-up appointment in 2 weeks.
-
 I am comfortable addressing with the patient conducting a screening to
 determine risk or presence of substance use disorder.

--- a/content/domains/manage/appropriate-pain-management-methods/post-assessment.md
+++ b/content/domains/manage/appropriate-pain-management-methods/post-assessment.md
@@ -6,15 +6,4 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-A 62-year old male patient presents to the clinic for extraction of
-unrestorable teeth #13, #14, #17 and #19. The last time this patient had
-multiple teeth extracted, in 1999, he reports that he was prescribed Codeine by
-Dr. Smith, which he remembers provided him great relief during his time of
-recovery.
-
-The patient’s former dentist, Dr. Smith, is a colleague of yours that you often
-to refer patients to. You explain to the patient that Codeine is not needed for
-pain management, and there are contraindications to prescribing Codeine for the
-extraction procedures that were completed on this date of service.
-
 I feel confident providing alternative and/or appropriate pain management methods.

--- a/content/domains/manage/assess-patient-history/post-assessment.md
+++ b/content/domains/manage/assess-patient-history/post-assessment.md
@@ -6,14 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-A 52-year old female patient presents to the clinic for a comprehensive
-examination. When reviewing the patient's medical and social history, you find
-that she has a history of smoking 5 cigarettes daily, but has not smoked a
-cigarette for 5 years.
-
-The patient's family history includes a deceased mother who was addicted to
-crystal meth, a father who is a recovering alcoholic, and a younger sister who
-has no significant findings. 
-
 Given a patient's family medical story, I feel comfortable assessing the risk
 of various treatment and pain management options.

--- a/content/domains/manage/importance-of-dental-provider/post-assessment.md
+++ b/content/domains/manage/importance-of-dental-provider/post-assessment.md
@@ -6,19 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-The opioid crisis is among the forefront of concerns in medicine, and dentists
-must share responsibility in minimizing the prescription of opioids.
-
-As early as 2016, a study published by the American Medical Association
-concluded that over 60 percent of 14-17 years olds were given a prescription
-for opioids after a tooth extraction. Patients with histories of tobacco use,
-and substance abuse, are more likely to use opioids long term. Comorbid
-health concerns including depression, and anxiety, are often independent
-predictors of opioid misuse.
-
-Communication with the patient, knowing where to go for help, where to refer,
-learning the signs of drug seeking behaviors, and managing pain conservatively
-can help curb these trends.
-
 I feel confident understanding the importance of a dentist's role in minimizing
 opioid exposure.

--- a/content/domains/refer/identify-resources/post-assessment.md
+++ b/content/domains/refer/identify-resources/post-assessment.md
@@ -6,10 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-You are a dentist that begins providing care at a health care center in
-Washington D.C. Knowing that Washington D.C. ranks third in opioid-related
-overdoses in the United States, you decide to identify resources in
-the community for substance use disorder services.
-
 I feel committed to learning about patient-community substance use disorder
 resources, beyond printed and digital referrals.

--- a/content/domains/refer/importance-of-collaboration/post-assessment.md
+++ b/content/domains/refer/importance-of-collaboration/post-assessment.md
@@ -6,18 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-As research prompts precautions, protocols evolve regarding prescribing opioids
-in the dental field. Dentistry continues to respond to the opioid epidemic by
-aligning itself with therapists, support services, community centers,
-hospitals, dental schools, rehabilitation centers, and other support services to
-facilitate a patient's healthy recovery. 
-
-A patient presents to the clinic with a toothache, and extraction is needed.
-The patient expresses frustration with ongoing tooth loss, and is not happy
-with her smile. You inquire more about the patients' mental health, and upon
-further discussion, she discloses that she smokes marijuana and uses other drugs
-from time to time. You decide collaboration with other social support providers
-is necessary.
-
 I feel confident understanding the intersection of dentistry, social support
 services, and the opioid epidemic.

--- a/content/domains/refer/knowledge-of-social-behavioral-treatment/post-assessment.md
+++ b/content/domains/refer/knowledge-of-social-behavioral-treatment/post-assessment.md
@@ -6,20 +6,5 @@ type: learning-objective-post-assessment
 weight: 3
 q1: ["Strongly disagree", "Disagree", "Neither agree nor disagree", "Agree", "Strongly agree"]
 ---
-A 20 year-old male patient presents to the clinic for a periodic examination.
-His medical history shows that he suffers from clinical depression, and is
-treated by a psychiatrist on campus. He has been your patient for 6 years, and
-is home for the summer from his sophomore year in college. He always has had
-excellent oral hygiene, and never has had dental caries. Upon today's
-examination the patient has one-surface caries on 6 teeth, with interproximal
-radiographic calculus.
-
-When questioned further, he explains the stresses of being a college student,
-and divulges that he has been taking a variety of prescription drugs given to
-him by his roommate. He begs you to not tell his parents of his
-"experimentation" with drugs &mdash; but realizes, through consultation, that he
-does have a problem. He does not want to participate in group rehabilitation
-but prefers individualized care. Which treatment options are available?
-
 To ensure this patient's follow-through, I would feel comfortable referring him
 to the appropriate substance use disorder services.

--- a/layouts/learning-objective-post-assessment/single.html.html
+++ b/layouts/learning-objective-post-assessment/single.html.html
@@ -18,12 +18,13 @@
                                                      data-learning-objective-url="{{ .Parent.Permalink }}">
                         <h1>{{ .Title }}</h1>
                         <article>
-                            {{ .Content }}
+                            {{ .Parent.Content }}
                         </article>
                     </main>
                     <section>
                         <form class="assessment-form">
-                            <h1 id="assessment-form-title">Indicate your level of agreement with the previous statement:</h1>
+                            <h1 id="assessment-form-title">Indicate your level of agreement with the following statement:</h1>
+                            <p>{{ .Content }}</p>
                             {{ $currentPage := . }}
                             {{ range $idx, $el := .Params.q1 }}
                             <div class="form-check">

--- a/layouts/learning-objective-post-assessment/single.html.html
+++ b/layouts/learning-objective-post-assessment/single.html.html
@@ -20,8 +20,6 @@
                         <article>
                             {{ .Parent.Content }}
                         </article>
-                    </main>
-                    <section>
                         <form class="assessment-form">
                             <h1 id="assessment-form-title">Indicate your level of agreement with the following statement:</h1>
                             <p>{{ .Content }}</p>
@@ -33,7 +31,7 @@
                             </div>
                             {{ end }}
                         </form>
-                    </section>
+                    </main>
                     <div class="container">
                         <nav class="row justify-content-center" aria-labelledby="lateral-navigation">
                             <div id="lateral-navigation" class="col-12 btn-toolbar justify-content-center">

--- a/layouts/learning-objective-pre-assessment/single.html.html
+++ b/layouts/learning-objective-pre-assessment/single.html.html
@@ -18,11 +18,6 @@
                                                      data-learning-objective="{{ .Parent.Title }}"
                                                      data-learning-objective-url="{{ .Parent.Permalink }}">
                         <h1>{{ .Title }}</h1>
-                        <article>
-                            {{ .Content }}
-                        </article>
-                    </main>
-                    <section>
                         <form class="assessment-form">
                             <h1 id="assessment-form-title">Indicate your level of agreement with the following statement:</h1>
                             <p>{{ .Content }}</p>
@@ -34,7 +29,7 @@
                             </div>
                             {{ end }}
                         </form>
-                    </section>
+                    </main>
 
                     <div class="container">
                         <nav class="row justify-content-center" aria-labelledby="lateral-navigation">

--- a/layouts/learning-objective-pre-assessment/single.html.html
+++ b/layouts/learning-objective-pre-assessment/single.html.html
@@ -24,7 +24,8 @@
                     </main>
                     <section>
                         <form class="assessment-form">
-                            <h1 id="assessment-form-title">Indicate your level of agreement with the previous statement:</h1>
+                            <h1 id="assessment-form-title">Indicate your level of agreement with the following statement:</h1>
+                            <p>{{ .Content }}</p>
                             {{ $currentPage := . }}
                             {{ range $idx, $el := .Params.q1 }}
                             <div class="form-check">


### PR DESCRIPTION
This updates the layout of the question pages such that:
- The copy of the post question is pulled from its parent, DRY
- The "Indicate" text preceeds the prompt